### PR TITLE
feat: swap proxy to using nesdie, remove rlib

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1816,6 +1816,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "nesdie"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f983dd9af3e62440e9067bc08ae479fb2839b413917555d4f73b2b96c0ca63a3"
+dependencies = [
+ "wee_alloc",
+]
+
+[[package]]
 name = "nix"
 version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2144,7 +2153,7 @@ checksum = "45604fc7a88158e7d514d8e22e14ac746081e7a70d7690074dd0029ee37458d6"
 name = "proxy"
 version = "0.1.0"
 dependencies = [
- "wee_alloc",
+ "nesdie",
 ]
 
 [[package]]

--- a/gateway/Cargo.toml
+++ b/gateway/Cargo.toml
@@ -8,7 +8,7 @@ description = "Account proxy contract"
 publish = false
 
 [lib]
-crate-type = ["cdylib", "rlib"]
+crate-type = ["cdylib"]
 
 [dependencies]
 near-sdk = "3.1.0"

--- a/proxy/Cargo.toml
+++ b/proxy/Cargo.toml
@@ -8,7 +8,7 @@ description = "Account proxy contract"
 publish = false
 
 [lib]
-crate-type = ["cdylib", "rlib"]
+crate-type = ["cdylib"]
 
 [dependencies]
-wee_alloc = { version = "0.4.5", default-features = false }
+nesdie = { version = "0.1", features = ["oom-handler"] }

--- a/proxy/src/lib.rs
+++ b/proxy/src/lib.rs
@@ -1,68 +1,23 @@
-#![no_std]
-#![feature(core_intrinsics)]
-#![feature(alloc_error_handler)]
+#![cfg_attr(target_arch = "wasm32", no_std)]
 
 extern crate alloc;
 
 use alloc::vec;
 
-#[global_allocator]
-static ALLOC: wee_alloc::WeeAlloc = wee_alloc::WeeAlloc::INIT;
-
-#[panic_handler]
-#[no_mangle]
-pub unsafe fn on_panic(_info: &::core::panic::PanicInfo) -> ! {
-    ::core::intrinsics::abort();
-}
-
-#[alloc_error_handler]
-#[no_mangle]
-pub unsafe fn on_alloc_error(_: core::alloc::Layout) -> ! {
-    ::core::intrinsics::abort();
-}
-
-#[allow(dead_code)]
-extern "C" {
-    fn read_register(register_id: u64, ptr: u64);
-    fn register_len(register_id: u64) -> u64;
-    fn current_account_id(register_id: u64);
-    fn predecessor_account_id(register_id: u64);
-    fn input(register_id: u64);
-    fn panic();
-    fn log_utf8(len: u64, ptr: u64);
-    fn promise_batch_create(account_id_len: u64, account_id_ptr: u64) -> u64;
-    fn promise_batch_action_function_call(
-        promise_index: u64,
-        method_name_len: u64,
-        method_name_ptr: u64,
-        arguments_len: u64,
-        arguments_ptr: u64,
-        amount_ptr: u64,
-        gas: u64,
-    );
-    fn promise_batch_action_deploy_contract(promise_index: u64, code_len: u64, code_ptr: u64);
-    fn promise_batch_action_transfer(promise_index: u64, amount_ptr: u64);
-}
-
-#[allow(dead_code)]
-fn log(message: &str) {
-    unsafe {
-        log_utf8(message.len() as _, message.as_ptr() as _);
-    }
-}
+use nesdie::sys;
 
 /// Check that predecessor of given account if suffix of given account.
 fn assert_predecessor() {
     unsafe {
-        current_account_id(0);
-        let current_account = vec![0u8; register_len(0) as usize];
-        read_register(0, current_account.as_ptr() as *const u64 as u64);
-        predecessor_account_id(1);
-        let mut predecessor_account = vec![0u8; (register_len(1) + 1) as usize];
+        sys::current_account_id(0);
+        let current_account = vec![0u8; sys::register_len(0) as usize];
+        sys::read_register(0, current_account.as_ptr() as *const u64 as u64);
+        sys::predecessor_account_id(1);
+        let mut predecessor_account = vec![0u8; (sys::register_len(1) + 1) as usize];
         predecessor_account[0] = b'.';
-        read_register(1, predecessor_account[1..].as_ptr() as *const u64 as u64);
+        sys::read_register(1, predecessor_account[1..].as_ptr() as *const u64 as u64);
         if !current_account.ends_with(&predecessor_account) {
-            panic();
+            sys::panic();
         }
     }
 }
@@ -83,12 +38,12 @@ fn slice_to_u32(s: &[u8]) -> u32 {
 /// Checks that predecessor is suffix of the given account.
 /// <gas:64><amount:u128><receiver_len:u32><receiver_id:bytes><method_name_len:u32><method_name:bytes><args_len:u32><args:bytes>
 #[no_mangle]
-pub extern "C" fn call() {
+pub fn call() {
     assert_predecessor();
     unsafe {
-        input(2);
-        let data = vec![0u8; register_len(2) as usize];
-        read_register(2, data.as_ptr() as *const u64 as u64);
+        sys::input(2);
+        let data = vec![0u8; sys::register_len(2) as usize];
+        sys::read_register(2, data.as_ptr() as *const u64 as u64);
         let gas = slice_to_u64(&data[..8]);
         let amount = &data[8..24]; // as u128;
         let receiver_len = slice_to_u32(&data[24..28]) as usize;
@@ -96,8 +51,8 @@ pub extern "C" fn call() {
         let args_len = slice_to_u32(
             &data[32 + receiver_len + method_name_len..36 + receiver_len + method_name_len],
         ) as usize;
-        let id = promise_batch_create(receiver_len as _, data.as_ptr() as u64 + 28);
-        promise_batch_action_function_call(
+        let id = sys::promise_batch_create(receiver_len as _, data.as_ptr() as u64 + 28);
+        sys::promise_batch_action_function_call(
             id,
             method_name_len as _,
             data.as_ptr() as u64 + 32 + receiver_len as u64,
@@ -112,25 +67,25 @@ pub extern "C" fn call() {
 /// Transfers given amount of $NEAR to given account.
 /// Input format <amount:u128><receiver_id:bytes>
 #[no_mangle]
-pub extern "C" fn transfer() {
+pub fn transfer() {
     assert_predecessor();
     unsafe {
-        input(2);
-        let data = vec![0u8; register_len(2) as usize];
-        read_register(2, data.as_ptr() as *const u64 as u64);
-        let id = promise_batch_create((data.len() - 16) as _, data.as_ptr() as u64 + 16);
-        promise_batch_action_transfer(id, data.as_ptr() as _);
+        sys::input(2);
+        let data = vec![0u8; sys::register_len(2) as usize];
+        sys::read_register(2, data.as_ptr() as *const u64 as u64);
+        let id = sys::promise_batch_create((data.len() - 16) as _, data.as_ptr() as u64 + 16);
+        sys::promise_batch_action_transfer(id, data.as_ptr() as _);
     }
 }
 
 /// This allows to update the contract on this account.
 /// Checks that predecessor is suffix of the given account.
 #[no_mangle]
-pub extern "C" fn update() {
+pub fn update() {
     assert_predecessor();
     unsafe {
-        let id = promise_batch_create(u64::MAX as _, 0 as _);
-        input(2);
-        promise_batch_action_deploy_contract(id, u64::MAX as _, 2 as _);
+        let id = sys::promise_batch_create(u64::MAX as _, 0 as _);
+        sys::input(2);
+        sys::promise_batch_action_deploy_contract(id, u64::MAX as _, 2 as _);
     }
 }


### PR DESCRIPTION
I didn't commit the rebuilt binary, since I'm not sure what workflow you have for that. Feel free to take it or not, I just did this as a PoC.

Also removes `rlib` crate type because it _should_ be unnecessary.